### PR TITLE
Refactor

### DIFF
--- a/pkg/handlers/user_handlers.go
+++ b/pkg/handlers/user_handlers.go
@@ -14,7 +14,7 @@ func CreateUser(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 	models.CreateUser(u)
-	return c.JSON(http.StatusOK, u)
+	return c.JSONPretty(http.StatusOK, u, " ")
 }
 
 func GetUser(c echo.Context) error {
@@ -26,12 +26,12 @@ func GetUser(c echo.Context) error {
 	if u == nil {
 		return echo.NewHTTPError(http.StatusNotFound, "No user with given ID found")
 	}
-	return c.JSON(http.StatusOK, u)
+	return c.JSONPretty(http.StatusOK, u, " ")
 }
 
 func GetAllUsers(c echo.Context) error {
 	users := models.GetAllUsers()
-	return c.JSON(http.StatusOK, users)
+	return c.JSONPretty(http.StatusOK, users, " ")
 }
 
 func UpdateUser(c echo.Context) error {
@@ -47,7 +47,7 @@ func UpdateUser(c echo.Context) error {
 	if err != nil {
 		return echo.NewHTTPError(http.StatusNotFound, err.Error())
 	}
-	return c.JSON(http.StatusOK, user)
+	return c.JSONPretty(http.StatusOK, user, " ")
 }
 
 func DeleteUser(c echo.Context) error {
@@ -58,5 +58,5 @@ func DeleteUser(c echo.Context) error {
 	if err := models.DeleteUser(id); err != nil {
 		return echo.NewHTTPError(http.StatusNotFound, err.Error())
 	}
-	return c.JSON(http.StatusNoContent, nil)
+	return c.JSONPretty(http.StatusNoContent, nil, " ")
 }

--- a/pkg/routes/routes.go
+++ b/pkg/routes/routes.go
@@ -7,9 +7,9 @@ import (
 
 // add new routes here
 var routes = []Route{
-	{"/api/user/:id/", http.MethodGet, handlers.GetUser},
-	{"/api/user/", http.MethodPost, handlers.CreateUser},
-	{"/api/users/", http.MethodGet, handlers.GetAllUsers},
-	{"/api/users/:userId/", http.MethodPut, handlers.UpdateUser},
-	{"/api/users/:userId/", http.MethodDelete, handlers.DeleteUser},
+	{"/api/users/:id", http.MethodGet, handlers.GetUser},
+	{"/api/users", http.MethodPost, handlers.CreateUser},
+	{"/api/users", http.MethodGet, handlers.GetAllUsers},
+	{"/api/users/:userId", http.MethodPut, handlers.UpdateUser},
+	{"/api/users/:userId", http.MethodDelete, handlers.DeleteUser},
 }


### PR DESCRIPTION
Minor refactorings

* Use plural nouns for all URLs. There was inconsistency as some resources used plural while others used singular. I think it makes more sense to use plural nouns and this also conforms to a lot of popular APIs.
* Remove trailing slash. I borrowed this pattern from django which automatically appended `/` to URLs and chrome used to do this to which lead to `404` errors when urls without forward slashes were sent to the server as chrome will append a forward slash. But I couldn't reproduce this on the latest version of chrome anymore and even if it does exist, this won't affect us as the api is not meant to be used in the browser.
* Use JSONPretty instead of JSON for a more readable output.