### PR TITLE
Fix bug with :userId path param

### DIFF
--- a/pkg/handlers/user_handlers.go
+++ b/pkg/handlers/user_handlers.go
@@ -39,7 +39,7 @@ func UpdateUser(c echo.Context) error {
 	if err := c.Bind(u); err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
-	id, err := strconv.Atoi(c.Param("userId"))
+	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
@@ -51,7 +51,7 @@ func UpdateUser(c echo.Context) error {
 }
 
 func DeleteUser(c echo.Context) error {
-	id, err := strconv.Atoi(c.Param("userId"))
+	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}

--- a/pkg/routes/routes.go
+++ b/pkg/routes/routes.go
@@ -10,6 +10,6 @@ var routes = []Route{
 	{"/api/users/:id", http.MethodGet, handlers.GetUser},
 	{"/api/users", http.MethodPost, handlers.CreateUser},
 	{"/api/users", http.MethodGet, handlers.GetAllUsers},
-	{"/api/users/:userId", http.MethodPut, handlers.UpdateUser},
-	{"/api/users/:userId", http.MethodDelete, handlers.DeleteUser},
+	{"/api/users/:id", http.MethodPut, handlers.UpdateUser},
+	{"/api/users/:id", http.MethodDelete, handlers.DeleteUser},
 }


### PR DESCRIPTION
Once a path param is registered with a particular name for an endpoint, other methods registered on that same endpoint with different path param names will be ignored. That is, if you have

`GET /users/:id` registered and try to register `PUT /users/:userId`, this will not work as `userId` will be ignored and when you query for that param inside the handler, it'll return an empty string which throws an error when you try to parse it with `strconv.Atoi()`